### PR TITLE
Implement FastEmit regularization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+dist/
 build/
 __pycache__/
 *.egg-info/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+build/
+__pycache__/
+*.egg-info/
+*.so

--- a/core.h
+++ b/core.h
@@ -22,7 +22,7 @@ rnntStatus_t run_warp_rnnt(cudaStream_t stream, unsigned int *counts, float *alp
 
 rnntStatus_t run_warp_rnnt_gather(cudaStream_t stream, unsigned int *counts, float *alphas, float *betas,
                                   const float *log_probs, float *grads, float *costs,
-                                  const int *xn, const int *yn, int N, int T, int U);
+                                  const int *xn, const int *yn, int N, int T, int U, float fastemit_lambda);
 
 #ifdef __cplusplus
 }

--- a/core.h
+++ b/core.h
@@ -18,7 +18,7 @@ extern "C" {
 
 rnntStatus_t run_warp_rnnt(cudaStream_t stream, unsigned int *counts, float *alphas, float *betas,
                            const int *labels, const float *log_probs, float *grads, float *costs,
-                           const int *xn, const int *yn, int N, int T, int U, int V, int blank);
+                           const int *xn, const int *yn, int N, int T, int U, int V, int blank, float fastemit_lambda);
 
 rnntStatus_t run_warp_rnnt_gather(cudaStream_t stream, unsigned int *counts, float *alphas, float *betas,
                                   const float *log_probs, float *grads, float *costs,

--- a/pytorch_binding/README.md
+++ b/pytorch_binding/README.md
@@ -8,7 +8,8 @@ def rnnt_loss(log_probs: torch.FloatTensor,
               average_frames: bool = False,
               reduction: Optional[AnyStr] = None,
               blank: int = 0,
-              gather: bool = False) -> torch.Tensor:
+              gather: bool = False,
+              fastemit_lambda: float = 0.0) -> torch.Tensor:
 
     """The CUDA-Warp RNN-Transducer loss.
 

--- a/pytorch_binding/README.md
+++ b/pytorch_binding/README.md
@@ -32,6 +32,9 @@ def rnnt_loss(log_probs: torch.FloatTensor,
             Default: 0.
         gather (bool, optional): Reduce memory consumption.
             Default: False.
+        fastemit_lambda (float, optional): FastEmit regularization
+            (https://arxiv.org/abs/2010.11148).
+            Default: 0.0.
     """
 ```
 

--- a/pytorch_binding/binding.cpp
+++ b/pytorch_binding/binding.cpp
@@ -92,7 +92,7 @@ std::tuple<at::Tensor, at::Tensor> rnnt_loss(
                                       xs.data<float>(),
                                       grads.data<float>(), costs.data<float>(),
                                       xn.data<int>(), yn.data<int>(),
-                                      N, T, U
+                                      N, T, U, fastemit_lambda
         );
 
     } else {

--- a/pytorch_binding/binding.cpp
+++ b/pytorch_binding/binding.cpp
@@ -32,7 +32,7 @@
 std::tuple<at::Tensor, at::Tensor> rnnt_loss(
         const at::Tensor& xs, const at::Tensor& ys,
         const at::Tensor& xn, const at::Tensor& yn,
-        const int blank) {
+        const int blank, const float fastemit_lambda) {
     // Check contiguous
     CHECK_CONTIGUOUS(xs);
     CHECK_CONTIGUOUS(ys);
@@ -103,7 +103,7 @@ std::tuple<at::Tensor, at::Tensor> rnnt_loss(
                                ys.data<int>(), xs.data<float>(),
                                grads.data<float>(), costs.data<float>(),
                                xn.data<int>(), yn.data<int>(),
-                               N, T, U, V, blank
+                               N, T, U, V, blank, fastemit_lambda
         );
     }
 
@@ -121,6 +121,7 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         pybind11::arg("ys"),
         pybind11::arg("xn"),
         pybind11::arg("yn"),
-        pybind11::arg("blank") = 0
+        pybind11::arg("blank") = 0,
+        pybind11::arg("fastemit_lambda") = 0.0
     );
 }

--- a/pytorch_binding/setup.py
+++ b/pytorch_binding/setup.py
@@ -27,7 +27,7 @@ long_description = get_long_description()
 
 setup(
     name="warp_rnnt",
-    version="0.4.0",
+    version="0.5.0",
     description="PyTorch bindings for CUDA-Warp RNN-Transducer",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -55,6 +55,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Scientific/Engineering",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development",

--- a/pytorch_binding/warp_rnnt/__init__.py
+++ b/pytorch_binding/warp_rnnt/__init__.py
@@ -9,18 +9,19 @@ __version__ = get_distribution('warp_rnnt').version
 class RNNTLoss(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, log_probs, labels, frames_lengths, labels_lengths, blank=0):
+    def forward(ctx, log_probs, labels, frames_lengths, labels_lengths, blank=0, fastemit_lambda=0.0):
         costs, ctx.grads = core.rnnt_loss(
             xs=log_probs, ys=labels,
             xn=frames_lengths, yn=labels_lengths,
             blank=blank,
+            fastemit_lambda=fastemit_lambda,
         )
         return costs
 
     @staticmethod
     def backward(ctx, grads_output):
         grads_output = grads_output.view(-1, 1, 1, 1).to(ctx.grads)
-        return ctx.grads.mul_(grads_output), None, None, None, None, None
+        return ctx.grads.mul_(grads_output), None, None, None, None, None, None
 
 
 def rnnt_loss(log_probs: torch.FloatTensor,
@@ -30,7 +31,8 @@ def rnnt_loss(log_probs: torch.FloatTensor,
               average_frames: bool = False,
               reduction: Optional[AnyStr] = None,
               blank: int = 0,
-              gather: bool = False) -> torch.Tensor:
+              gather: bool = False,
+              fastemit_lambda: float = 0.0) -> torch.Tensor:
 
     """The CUDA-Warp RNN-Transducer loss.
 
@@ -77,7 +79,7 @@ def rnnt_loss(log_probs: torch.FloatTensor,
 
         blank = -1
 
-    costs = RNNTLoss.apply(log_probs, labels, frames_lengths, labels_lengths, blank)
+    costs = RNNTLoss.apply(log_probs, labels, frames_lengths, labels_lengths, blank, fastemit_lambda)
 
     if average_frames:
         costs = costs / frames_lengths.to(log_probs)

--- a/pytorch_binding/warp_rnnt/__init__.py
+++ b/pytorch_binding/warp_rnnt/__init__.py
@@ -56,6 +56,9 @@ def rnnt_loss(log_probs: torch.FloatTensor,
             Default: 0.
         gather (bool, optional): Reduce memory consumption.
             Default: False.
+        fastemit_lambda (float, optional): FastEmit regularization
+            (https://arxiv.org/abs/2010.11148).
+            Default: 0.0.
     """
 
     assert average_frames is None or isinstance(average_frames, bool)

--- a/tensorflow_binding/requirements.txt
+++ b/tensorflow_binding/requirements.txt
@@ -1,0 +1,1 @@
+tensorflow-gpu~=1.15.0

--- a/tensorflow_binding/transducer_tensorflow/__init__.py
+++ b/tensorflow_binding/transducer_tensorflow/__init__.py
@@ -1,7 +1,6 @@
 import imp
 import tensorflow as tf
 from tensorflow.python.framework import ops
-from tensorflow.python.ops.nn_grad import _BroadcastMul
 from typing import Optional, AnyStr
 
 lib_file = imp.find_module('kernels', __path__)[1]
@@ -83,7 +82,8 @@ def transducer_loss(
         average_frames: bool = False,
         reduction: Optional[AnyStr] = None,
         blank: int = 0,
-        gather: bool = False):
+        gather: bool = False,
+        fastemit_lambda: float = 0.0):
     """The CUDA-Warp Transducer loss.
 
     Args:
@@ -106,6 +106,9 @@ def transducer_loss(
             Default: 0.
         gather (bool, optional): Reduce memory consumption.
             Default: False.
+        fastemit_lambda (float, optional): FastEmit regularization
+            (https://arxiv.org/abs/2010.11148).
+            Default: 0.0.
     """
     assert average_frames is None or isinstance(average_frames, bool)
     assert reduction is None or reduction in ("none", "mean", "sum")
@@ -116,7 +119,7 @@ def transducer_loss(
         blank = -1
 
     costs, _ = _warp_transducer.transducer_loss(
-        log_probs, labels, frames_lengths, labels_lengths, blank)
+        log_probs, labels, frames_lengths, labels_lengths, blank, fastemit_lambda)
 
     if average_frames:
         costs = costs / frames_lengths  # (N,)


### PR DESCRIPTION
Hey!

Thank you for this great library!

This PR implements `FastEmit` regularization from https://arxiv.org/abs/2010.11148.
The gradients of all non-blank symbols are scaled up by a small factor (around `1.004`).
Intuitively, the model is encouraged to output symbols faster, thus reducing latency.

![image](https://user-images.githubusercontent.com/12550267/129022131-1afca95f-8f37-407a-8055-b15ee73681d2.png)
